### PR TITLE
Fix initialization of tokenizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-packages/
+packages
 pubspec.lock
-bin/
+# bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 packages
 pubspec.lock
-# bin/

--- a/bin/startc/starts.dart
+++ b/bin/startc/starts.dart
@@ -331,6 +331,7 @@ Token nextToken()
 void initializeTokenizer(String script)
 {
   _line = 0;
+  _position = 0;
   _script = script;
   if (_script == null) error("could not open file");
   _line = 1;


### PR DESCRIPTION
Previously wasn't able to compile two different programs in one run because the tokenizer `_position` variable was not being reset, so it would immediately jump to wherever it left off on the last parse.

Also changed `.gitignore` to not ignore my change. Seems like we just wanted to ignore the `packages` directories, which I have done with my change.
