### PR TITLE
Initialize Type statics.

### DIFF
--- a/lib/starti.dart
+++ b/lib/starti.dart
@@ -303,6 +303,9 @@ int resolveOperand(Memory memory, RegisterStack reg, String operand) {
 
 String execute(String bytecode, { bool debug: false }) {
   // Builtin types.
+  Type.idMap = new Map();
+  Type.typeMap = new Map();
+  Type._idgen = 0;
   final inttype = new Type("int", []);
   final booltype = new Type("bool", []);
   final listtype = new Type("List", ["length#$WORD_SIZE:int"]);


### PR DESCRIPTION
Seems like the intention is for each call to 'execute' to be independent, and since new builtin types are created there, too, it seemed appropriate to re-initialize the static variables in Type.

This came up because our implementation runs the dart interpreter _from_ dart, and we execute the code multiple times, but got different type-id's.
